### PR TITLE
fix loading lib files

### DIFF
--- a/lib/resync.rb
+++ b/lib/resync.rb
@@ -1,4 +1,6 @@
 # A Ruby gem for working with the {http://www.openarchives.org/rs/1.0/resourcesync ResourceSync} web synchronization framework.
 module Resync
-  Dir.glob(File.expand_path('../resync/*.rb', __FILE__), &method(:require))
+  Dir.glob(File.expand_path('../resync/*.rb', __FILE__)).sort.each do |filename|
+    require filename
+  end
 end


### PR DESCRIPTION
I got the following error when I tried to load resync gem.

```sh
$ irb
irb(main):001:0> require 'resync'
NameError: uninitialized constant Resync::XMLParser::CapabilityList
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync/xml_parser.rb:9:in `<module:XMLParser>'
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync/xml_parser.rb:4:in `<module:Resync>'
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync/xml_parser.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync.rb:3:in `glob'
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync.rb:3:in `<module:Resync>'
	from /var/lib/gems/2.2.0/gems/resync-0.3.3/lib/resync.rb:2:in `<top (required)>'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
	from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from (irb):1
	from /usr/bin/irb:11:in `<main>'
```

This pull request will fix the problem.