### PR TITLE
add datetime attribute to Metadata

### DIFF
--- a/lib/resync/metadata.rb
+++ b/lib/resync/metadata.rb
@@ -36,6 +36,7 @@ module Resync
     time_node :from_time, '@from', default_value: nil
     time_node :until_time, '@until', default_value: nil
     time_node :completed_time, '@completed', default_value: nil
+    time_node :datetime, '@datetime', default_value: nil
     typesafe_enum_node :change, '@change', class: Types::Change, default_value: nil
     text_node :capability, '@capability', default_value: nil
 
@@ -69,6 +70,7 @@ module Resync
         until_time: nil,
         completed_time: nil,
         modified_time: nil,
+        datetime: nil,
 
         length: nil,
         mime_type: nil,
@@ -85,6 +87,7 @@ module Resync
       self.from_time = from_time
       self.until_time = until_time
       self.completed_time = completed_time
+      self.datetime = datetime
 
       self.change = change
       self.capability = capability
@@ -107,6 +110,10 @@ module Resync
 
     def completed_time=(value)
       @completed_time = time_or_nil(value)
+    end
+
+    def datetime=(value)
+      @datetime = time_or_nil(value)
     end
   end
 end

--- a/spec/acceptance/xml_parser_spec.rb
+++ b/spec/acceptance/xml_parser_spec.rb
@@ -476,7 +476,8 @@ module Resync
 
       expected_filenames = %w[res1 res2 res3 res2]
       expected_extensions = %w[html pdf tiff pdf]
-      expected_lastmods = [Time.utc(2013, 1, 3, 11), Time.utc(2013, 1, 3, 13), Time.utc(2013, 1, 3, 18), Time.utc(2013, 1, 3, 21)]
+      expected_lastmods = [Time.utc(2000, 1, 1, 1, 1), Time.utc(2013, 1, 3, 13), nil, nil]
+      expected_datetimes = [Time.utc(2013, 1, 3, 11), Time.utc(2013, 1, 3, 13), Time.utc(2013, 1, 3, 18), nil]
 
       expected_changes = [Types::Change::CREATED, Types::Change::UPDATED, Types::Change::DELETED, Types::Change::UPDATED]
 
@@ -485,6 +486,7 @@ module Resync
         expect(url.uri).to eq(URI("http://example.com/#{expected_filenames[i]}.#{expected_extensions[i]}"))
         expect(url.modified_time).to be_time(expected_lastmods[i])
         expect(url.metadata.change).to eq(expected_changes[i])
+        expect(url.metadata.datetime).to eq(expected_datetimes[i])
       end
     end
 
@@ -541,7 +543,8 @@ module Resync
 
       expected_filenames = %w[res7 res9 res5 res7]
       expected_extensions = %w[html pdf tiff html]
-      expected_lastmods = [
+      expected_lastmods = [nil, nil, nil, nil]
+      expected_datetimes = [
         Time.utc(2013, 1, 2, 12),
         Time.utc(2013, 1, 2, 13),
         Time.utc(2013, 1, 2, 19),
@@ -621,29 +624,35 @@ module Resync
       urls = urlset.resources
       expect(urls.size).to eq(4)
 
-      expected_filenames = %w[res7 res9 res5 res7]
-      expected_extensions = %w[html pdf tiff html]
+      expected_filenames = %w[res7 res9 res7 res5]
+      expected_extensions = %w[html pdf html tiff]
       expected_lastmods = [
         Time.utc(2013, 1, 2, 12),
         Time.utc(2013, 1, 2, 13),
-        Time.utc(2013, 1, 2, 19),
-        Time.utc(2013, 1, 2, 20)
+        Time.utc(2013, 1, 2, 20),
+        nil
       ]
-      expected_changes = [Types::Change::CREATED, Types::Change::UPDATED, Types::Change::DELETED, Types::Change::UPDATED]
+      expected_datetimes = [
+        Time.utc(2013, 1, 2, 12),
+        Time.utc(2013, 1, 2, 13),
+        Time.utc(2013, 1, 2, 20),
+        Time.utc(2013, 1, 2, 19)
+      ]
+      expected_changes = [Types::Change::CREATED, Types::Change::UPDATED, Types::Change::UPDATED, Types::Change::DELETED]
       expected_hashes = [
         { 'md5' => '1c1b0e264fa9b7e1e9aa6f9db8d6362b' },
         { 'md5' => 'f906610c3d4aa745cb2b986f25b37c5a' },
-        {},
-        { 'md5' => '0988647082c8bc51778894a48ec3b576' }
+        { 'md5' => '0988647082c8bc51778894a48ec3b576' },
+        {}
       ]
-      expected_lengths = [4339, 38_297, nil, 5426]
+      expected_lengths = [4339, 38_297, 5426, nil]
       expected_types = [
         'text/html',
         'application/pdf',
-        nil,
-        'text/html'
+        'text/html',
+        nil
       ]
-      expected_paths = ['/changes/res7.html', '/changes/res9.pdf', nil, '/changes/res7-v2.html']
+      expected_paths = ['/changes/res7.html', '/changes/res9.pdf', '/changes/res7-v2.html', nil]
 
       (0..3).each do |i|
         url = urls[i]
@@ -720,20 +729,21 @@ module Resync
 
       url = urls[0]
       expect(url.uri).to eq(URI('http://example.com/res1'))
-      expect(url.modified_time).to be_time(Time.utc(2013, 1, 3, 18))
+      expect(url.modified_time).to be_nil
       md = url.metadata
       expect(md.change).to be(Types::Change::UPDATED)
+      expect(md.datetime).to be_time(Time.utc(2013, 1, 3, 18))
       links = url.links
       expect(links.size).to eq(2)
       ln0 = links[0]
       expect(ln0.rel).to eq('alternate')
       expect(ln0.uri).to eq(URI('http://example.com/res1.html'))
-      expect(ln0.modified_time).to be_time(Time.utc(2013, 1, 3, 18))
+      expect(ln0.modified_time).to be_nil
       expect(ln0.mime_type).to be_mime_type('text/html')
       ln1 = links[1]
       expect(ln1.rel).to eq('alternate')
       expect(ln1.uri).to eq(URI('http://example.com/res1.pdf'))
-      expect(ln1.modified_time).to be_time(Time.utc(2013, 1, 3, 18))
+      expect(ln1.modified_time).to be_nil
       expect(ln1.mime_type).to be_mime_type('application/pdf')
     end
 
@@ -757,11 +767,12 @@ module Resync
 
       url = urls[0]
       expect(url.uri).to eq(URI('http://example.com/res1.html'))
-      expect(url.modified_time).to be_time(Time.utc(2013, 1, 3, 18))
+      expect(url.modified_time).to be_nil
       md = url.metadata
       expect(md.change).to be(Types::Change::UPDATED)
       expect(md.hashes).to eq('md5' => '1584abdf8ebdc9802ac0c6a7402c03b6')
       expect(md.length).to eq(8876)
+      expect(md.datetime).to be_time(Time.utc(2013, 1, 3, 18))
       links = url.links
       expect(links.size).to eq(1)
       ln = links[0]
@@ -845,32 +856,34 @@ module Resync
 
       url0 = urls[0]
       expect(url0.uri).to eq(URI('http://example.com/res2.pdf'))
-      expect(url0.modified_time).to be_time(Time.utc(2013, 1, 3, 18))
+      expect(url0.modified_time).to be_nil
       md0 = url0.metadata
       expect(md0.change).to be(Types::Change::UPDATED)
       expect(md0.hashes).to eq('md5' => '1584abdf8ebdc9802ac0c6a7402c03b6')
       expect(md0.length).to eq(8876)
       expect(md0.mime_type).to be_mime_type('application/pdf')
+      expect(md0.datetime).to be_time(Time.utc(2013, 1, 3, 18))
       lns0 = url0.links
       expect(lns0.size).to eq(1)
       ln0 = lns0[0]
       expect(ln0.rel).to(eq('describedby'))
       expect(ln0.uri).to(eq(URI('http://example.com/res2_dublin-core_metadata.xml')))
-      expect(ln0.modified_time).to(eq(Time.utc(2013, 1, 1, 12)))
+      expect(ln0.modified_time).to be_nil
       expect(ln0.mime_type).to(be_mime_type('application/xml'))
 
       url1 = urls[1]
       expect(url1.uri).to eq(URI('http://example.com/res2_dublin-core_metadata.xml'))
-      expect(url1.modified_time).to be_time(Time.utc(2013, 1, 3, 19))
+      expect(url1.modified_time).to be_nil
       md1 = url1.metadata
       expect(md1.change).to be(Types::Change::UPDATED)
       expect(md1.mime_type).to be_mime_type('application/xml')
+      expect(md1.datetime).to be_time(Time.utc(2013, 1, 3, 19))
       lns1 = url1.links
       expect(lns1.size).to eq(2)
       ln1 = lns1[0]
       expect(ln1.rel).to(eq('describes'))
       expect(ln1.uri).to(eq(URI('http://example.com/res2.pdf')))
-      expect(ln1.modified_time).to(eq(Time.utc(2013, 1, 3, 18)))
+      expect(ln1.modified_time).to be_nil
       expect(ln1.hashes).to(eq('md5' => '1584abdf8ebdc9802ac0c6a7402c03b6'))
       expect(ln1.length).to(eq(8876))
       expect(ln1.mime_type).to(be_mime_type('application/pdf'))

--- a/spec/acceptance/xml_parser_spec.rb
+++ b/spec/acceptance/xml_parser_spec.rb
@@ -65,20 +65,30 @@ module Resync
       expect(urlset).to be_a(ChangeList)
 
       urls = urlset.resources
-      expect(urls.size).to eq(2)
+      expect(urls.size).to eq(3)
       url0 = urls[0]
-      expect(url0.uri).to eq(URI('http://example.com/res2.pdf'))
-      expect(url0.modified_time).to be_time(Time.utc(2013, 1, 2, 13))
+      expect(url0.uri).to eq(URI('http://example.com/res3.tiff'))
+      expect(url0.modified_time).to be_time(Time.utc(2011, 1, 1, 0))
       md0 = url0.metadata
       expect(md0).not_to be_nil
-      expect(md0.change).to be(Resync::Types::Change::UPDATED)
+      expect(md0.change).to be(Resync::Types::Change::CREATED)
+      expect(md0.datetime).to be_time(Time.utc(2013, 1, 2, 15))
 
       url1 = urls[1]
-      expect(url1.uri).to eq(URI('http://example.com/res3.tiff'))
-      expect(url1.modified_time).to be_time(Time.utc(2013, 1, 2, 18))
+      expect(url1.uri).to eq(URI('http://example.com/res1.pdf'))
+      expect(url1.modified_time).to be_time(Time.utc(2013, 1, 2, 13))
       md1 = url1.metadata
       expect(md1).not_to be_nil
-      expect(md1.change).to be(Resync::Types::Change::DELETED)
+      expect(md1.change).to be(Resync::Types::Change::UPDATED)
+      expect(md1.datetime).to be_time(Time.utc(2013, 1, 2, 13))
+
+      url2 = urls[2]
+      expect(url2.uri).to eq(URI('http://example.com/res2.pdf'))
+      expect(url2.modified_time).to be_nil
+      md2 = url2.metadata
+      expect(md2).not_to be_nil
+      expect(md2.change).to be(Resync::Types::Change::DELETED)
+      expect(md2.datetime).to be_time(Time.utc(2013, 1, 2, 14))
     end
 
     it 'parses example 4' do

--- a/spec/data/examples/example-19.xml
+++ b/spec/data/examples/example-19.xml
@@ -7,22 +7,20 @@
          from="2013-01-03T00:00:00Z"/>
   <url>
     <loc>http://example.com/res1.html</loc>
-    <lastmod>2013-01-03T11:00:00Z</lastmod>
-    <rs:md change="created"/>
+    <lastmod>2000-01-01T01:01:00Z</lastmod>
+    <rs:md change="created" datetime="2013-01-03T11:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res2.pdf</loc>
     <lastmod>2013-01-03T13:00:00Z</lastmod>
-    <rs:md change="updated"/>
+    <rs:md change="updated" datetime="2013-01-03T13:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res3.tiff</loc>
-    <lastmod>2013-01-03T18:00:00Z</lastmod>
-    <rs:md change="deleted"/>
+    <rs:md change="deleted" datetime="2013-01-03T18:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res2.pdf</loc>
-    <lastmod>2013-01-03T21:00:00Z</lastmod>
     <rs:md change="updated"/>
   </url>
 </urlset>

--- a/spec/data/examples/example-21.xml
+++ b/spec/data/examples/example-21.xml
@@ -10,22 +10,18 @@
          until="2013-01-03T00:00:00Z"/>
   <url>
     <loc>http://example.com/res7.html</loc>
-    <lastmod>2013-01-02T12:00:00Z</lastmod>
-    <rs:md change="created"/>
+    <rs:md change="created" datetime="2013-01-02T12:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res9.pdf</loc>
-    <lastmod>2013-01-02T13:00:00Z</lastmod>
-    <rs:md change="updated"/>
+    <rs:md change="updated" datetime="2013-01-02T13:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res5.tiff</loc>
-    <lastmod>2013-01-02T19:00:00Z</lastmod>
-    <rs:md change="deleted"/>
+    <rs:md change="deleted" datetime="2013-01-02T19:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res7.html</loc>
-    <lastmod>2013-01-02T20:00:00Z</lastmod>
-    <rs:md change="updated"/>
+    <rs:md change="updated" datetime="2013-01-02T20:00:00Z"/>
   </url>
 </urlset>

--- a/spec/data/examples/example-23.xml
+++ b/spec/data/examples/example-23.xml
@@ -10,6 +10,7 @@
     <loc>http://example.com/res7.html</loc>
     <lastmod>2013-01-02T12:00:00Z</lastmod>
     <rs:md change="created"
+           datetime="2013-01-02T12:00:00Z"
            hash="md5:1c1b0e264fa9b7e1e9aa6f9db8d6362b"
            length="4339"
            type="text/html"
@@ -19,6 +20,7 @@
     <loc>http://example.com/res9.pdf</loc>
     <lastmod>2013-01-02T13:00:00Z</lastmod>
     <rs:md change="updated"
+           datetime="2013-01-02T13:00:00Z"
            hash="md5:f906610c3d4aa745cb2b986f25b37c5a"
            length="38297"
            type="application/pdf"
@@ -26,13 +28,15 @@
   </url>
   <url>
     <loc>http://example.com/res5.tiff</loc>
-    <lastmod>2013-01-02T19:00:00Z</lastmod>
-    <rs:md change="deleted"/>
+    <rs:md change="deleted"
+           datetime="2013-01-02T19:00:00Z"/>
+
   </url>
   <url>
     <loc>http://example.com/res7.html</loc>
     <lastmod>2013-01-02T20:00:00Z</lastmod>
     <rs:md change="updated"
+           datetime="2013-01-02T20:00:00Z"
            hash="md5:0988647082c8bc51778894a48ec3b576"
            length="5426"
            type="text/html"

--- a/spec/data/examples/example-25.xml
+++ b/spec/data/examples/example-25.xml
@@ -7,15 +7,13 @@
          from="2013-01-03T11:00:00Z"/>
   <url>
     <loc>http://example.com/res1</loc>
-    <lastmod>2013-01-03T18:00:00Z</lastmod>
-    <rs:md change="updated"/>
+    <rs:md change="updated"
+           datetime="2013-01-03T18:00:00Z"/>
     <rs:ln rel="alternate"
            href="http://example.com/res1.html"
-           modified="2013-01-03T18:00:00Z"
            type="text/html"/>
     <rs:ln rel="alternate"
            href="http://example.com/res1.pdf"
-           modified="2013-01-03T18:00:00Z"
            type="application/pdf"/>
   </url>
 </urlset>

--- a/spec/data/examples/example-26.xml
+++ b/spec/data/examples/example-26.xml
@@ -7,8 +7,8 @@
          from="2013-01-03T00:00:00Z"/>
   <url>
     <loc>http://example.com/res1.html</loc>
-    <lastmod>2013-01-03T18:00:00Z</lastmod>
     <rs:md change="updated"
+           datetime="2013-01-03T18:00:00Z"
            hash="md5:1584abdf8ebdc9802ac0c6a7402c03b6"
            length="8876"/>
     <rs:ln rel="canonical"

--- a/spec/data/examples/example-28.xml
+++ b/spec/data/examples/example-28.xml
@@ -7,24 +7,22 @@
          from="2013-01-03T00:00:00Z"/>
   <url>
     <loc>http://example.com/res2.pdf</loc>
-    <lastmod>2013-01-03T18:00:00Z</lastmod>
     <rs:md change="updated"
+           datetime="2013-01-03T18:00:00Z"
            hash="md5:1584abdf8ebdc9802ac0c6a7402c03b6"
            length="8876"
            type="application/pdf"/>
     <rs:ln rel="describedby"
            href="http://example.com/res2_dublin-core_metadata.xml"
-           modified="2013-01-01T12:00:00Z"
            type="application/xml"/>
   </url>
   <url>
     <loc>http://example.com/res2_dublin-core_metadata.xml</loc>
-    <lastmod>2013-01-03T19:00:00Z</lastmod>
     <rs:md change="updated"
+           datetime="2013-01-03T19:00:00Z"
            type="application/xml"/>
     <rs:ln rel="describes"
            href="http://example.com/res2.pdf"
-           modified="2013-01-03T18:00:00Z"
            hash="md5:1584abdf8ebdc9802ac0c6a7402c03b6"
            length="8876"
            type="application/pdf"/>

--- a/spec/data/examples/example-3.xml
+++ b/spec/data/examples/example-3.xml
@@ -5,13 +5,17 @@
          from="2013-01-02T00:00:00Z"
          until="2013-01-03T00:00:00Z"/>
   <url>
-    <loc>http://example.com/res2.pdf</loc>
+    <loc>http://example.com/res1.pdf</loc>
     <lastmod>2013-01-02T13:00:00Z</lastmod>
-    <rs:md change="updated"/>
+    <rs:md change="updated" datetime="2013-01-02T13:00:00Z"/>
+  </url>
+  <url>
+    <loc>http://example.com/res2.pdf</loc>
+    <rs:md change="deleted" datetime="2013-01-02T14:00:00Z"/>
   </url>
   <url>
     <loc>http://example.com/res3.tiff</loc>
-    <lastmod>2013-01-02T18:00:00Z</lastmod>
-    <rs:md change="deleted"/>
+    <lastmod>2011-01-01T00:00:00Z</lastmod>
+    <rs:md change="created" datetime="2013-01-02T15:00:00Z"/>
   </url>
 </urlset>

--- a/spec/unit/resync/change_dump_manifest_spec.rb
+++ b/spec/unit/resync/change_dump_manifest_spec.rb
@@ -24,29 +24,35 @@ module Resync
           urls = urlset.resources
           expect(urls.size).to eq(4)
 
-          expected_filenames = %w[res7 res9 res5 res7]
-          expected_extensions = %w[html pdf tiff html]
+          expected_filenames = %w[res7 res9 res7 res5]
+          expected_extensions = %w[html pdf html tiff]
           expected_lastmods = [
             Time.utc(2013, 1, 2, 12),
             Time.utc(2013, 1, 2, 13),
-            Time.utc(2013, 1, 2, 19),
-            Time.utc(2013, 1, 2, 20)
+            Time.utc(2013, 1, 2, 20),
+            nil
           ]
-          expected_changes = [Types::Change::CREATED, Types::Change::UPDATED, Types::Change::DELETED, Types::Change::UPDATED]
+          expected_datetimes = [
+            Time.utc(2013, 1, 2, 12),
+            Time.utc(2013, 1, 2, 13),
+            Time.utc(2013, 1, 2, 20),
+            Time.utc(2013, 1, 2, 19)
+          ]
+          expected_changes = [Types::Change::CREATED, Types::Change::UPDATED, Types::Change::UPDATED, Types::Change::DELETED]
           expected_hashes = [
             { 'md5' => '1c1b0e264fa9b7e1e9aa6f9db8d6362b' },
             { 'md5' => 'f906610c3d4aa745cb2b986f25b37c5a' },
-            {},
-            { 'md5' => '0988647082c8bc51778894a48ec3b576' }
+            { 'md5' => '0988647082c8bc51778894a48ec3b576' },
+            {}
           ]
-          expected_lengths = [4339, 38_297, nil, 5426]
+          expected_lengths = [4339, 38_297, 5426, nil]
           expected_types = [
             'text/html',
             'application/pdf',
-            nil,
-            'text/html'
+            'text/html',
+            nil
           ]
-          expected_paths = ['/changes/res7.html', '/changes/res9.pdf', nil, '/changes/res7-v2.html']
+          expected_paths = ['/changes/res7.html', '/changes/res9.pdf', '/changes/res7-v2.html', nil]
 
           (0..3).each do |i|
             url = urls[i]
@@ -58,6 +64,7 @@ module Resync
             expect(md.length).to eq(expected_lengths[i])
             expect(md.mime_type).to be_mime_type(expected_types[i])
             expect(md.path).to eq(expected_paths[i])
+            expect(md.datetime).to eq(expected_datetimes[i])
           end
         end
       end

--- a/spec/unit/resync/metadata_spec.rb
+++ b/spec/unit/resync/metadata_spec.rb
@@ -71,6 +71,20 @@ module Resync
           expect { Metadata.new(completed_time: '12:45 pm') }.to raise_error(ArgumentError)
         end
 
+        it 'accepts a datetime timestamp' do
+          datetime = Time.utc(1997, 7, 16, 19, 20, 30.45)
+          metadata = Metadata.new(datetime: datetime)
+          expect(metadata.datetime).to be_time(datetime)
+        end
+
+        it 'defaults to nil if no datetime timestamp is specified' do
+          metadata = Metadata.new
+          expect(metadata.datetime).to be_nil
+        end
+
+        it 'fails if the datetime timestamp is not a time' do
+          expect { Metadata.new(datetime: '12:45 pm') }.to raise_error(ArgumentError)
+        end
       end
 
       describe 'capability' do


### PR DESCRIPTION
This PR will add `datetime` attribute to Resync::Metadata to support ChangeList in ResourceSync 1.1. It just allows setting `datetime` not to break compatibility.
https://github.com/CDLUC3/resync/issues/3#issuecomment-1100831851

I'll add some more tests later.